### PR TITLE
fix broken link on table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There are some examples in `./env_examples/` folder.
 | Llama-2-13b-chat-hf on GPU        | .env.13b_example            |
 | ...                               | ...                         |
 
-### Start  Web UI
+### Start Web UI
 
 Run chatbot with web UI:
 


### PR DESCRIPTION
The link for "Start Web UI" is broken, so I find the reason why and fixed it.

the header have 1 more space on it.